### PR TITLE
upgraded PyYAML due to a security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.0.2
 elasticsearch==6.3.1
-PyYAML==3.13
+PyYAML==4.2b1


### PR DESCRIPTION
PyYAML versions seem to be released in the wrong order, and we were originally using a version (3.13) that has an RCE vulnerability.  Upgraded to 4.2b1, which fixes the issue.